### PR TITLE
fix type_label html-escaping issue

### DIFF
--- a/templates/partials/result_inline.html
+++ b/templates/partials/result_inline.html
@@ -1,7 +1,7 @@
 <li class="ui-field-contain{{#type}}{{#is_numeric}} numeric{{/is_numeric}}{{/type}}">
   <input type="hidden" name="results[{{@index}}][type_id]" value="{{type_id}}">
   <label for="result-{{@index}}-value">
-    {{type_label}}
+    {{{type_label}}}
   </label>
   {{#type}}
   {{#is_numeric}}

--- a/templates/report_detail.html
+++ b/templates/report_detail.html
@@ -27,7 +27,7 @@
           </tr>
           {{#results}}
           <tr>
-            <th>{{type_label}}</th>
+            <th>{{{type_label}}}</th>
             <td>{{value}}</td>
           </tr>
           {{/results}}


### PR DESCRIPTION
For some reason report form labels are returned from the server already
html-escaped (e.g. "Child&#x27;s Name").  Use the triple bracket to tell
mustache to render those verbatim.

This is probably the wrong place to fix this though.  We probably should
fix server-side so those labels are returned unescaped by the server.
Then let mustache do it's normal job of html-escaping.